### PR TITLE
'Detect' has no case defined?

### DIFF
--- a/src/Html/UrlServiceProvider.php
+++ b/src/Html/UrlServiceProvider.php
@@ -26,7 +26,7 @@ class UrlServiceProvider extends ServiceProvider
      */
     public function forceUrlGeneratorPolicy()
     {
-        $policy = $this->app['config']->get('system.urlPolicy', 'detect');
+        $policy = $this->app['config']->get('system.urlPolicy', 'force');
 
         switch (strtolower($policy)) {
             case 'force':


### PR DESCRIPTION
I get a mish-mash of https and http urls in tastyigniter. 

No case has been defined for 'detect', and unwilling to rename a case incase these definitions are used elsewhere