### PR TITLE
Simplify start and end times

### DIFF
--- a/src/Location/WorkingSchedule.php
+++ b/src/Location/WorkingSchedule.php
@@ -318,7 +318,7 @@ class WorkingSchedule
     public function getTimeslot(int $interval = 15, DateTime $dateTime = null, int $leadTime = 25)
     {
         $dateTime = Carbon::instance($this->parseDate($dateTime));
-        $checkDateTime = $dateTime->copy()->addMinutes($leadTime * 2);
+        $checkDateTime = $dateTime->copy();
         $interval = new DateInterval('PT'.($interval ?: 15).'M');
         $leadTime = new DateInterval('PT'.($leadTime ?: 25).'M');
 
@@ -445,10 +445,7 @@ class WorkingSchedule
             if ($range->endsNextDay())
                 $end->add(new DateInterval('P1D'));
 
-            if (!is_null($leadTime)) {
-                $start = $start->add($leadTime);
-                $end = $end->sub($leadTime);
-            }
+            $start = $start->add($leadTime);
 
             $datePeriod = new DatePeriod($start, $interval, $end);
             foreach ($datePeriod as $dateTime) {


### PR DESCRIPTION
As discussed here: https://github.com/tastyigniter/TastyIgniter/issues/553

Remove the double lead time on start times
Allow orders right up to end time.

Makes the timeslots 'feel' correct