### PR TITLE
Remove is_callable

### DIFF
--- a/src/Traits/ExtendableTrait.php
+++ b/src/Traits/ExtendableTrait.php
@@ -424,7 +424,7 @@ trait ExtendableTrait
             $extension = $this->extensionData['methods'][$name];
             $extensionObject = $this->extensionData['extensions'][$extension];
 
-            if (method_exists($extension, $name) && is_callable([$extension, $name])) {
+            if (method_exists($extension, $name)) {
                 return call_user_func_array([$extensionObject, $name], $params);
             }
         }


### PR DESCRIPTION
The ability to call non-static methods statically has been removed. Thus is_callable() will fail when checking for a non-static method with a classname (must check with an object instance).

Ref: https://www.php.net/manual/en/migration80.incompatible.php

See October:
https://github.com/octobercms/library/blob/49b4729e968f9b9750c2cd809fba642addbea077/src/Extension/ExtendableTrait.php#L413

https://github.com/tastyigniter/TastyIgniter/issues/726