### PR TITLE
Missing subtotalWithoutConditions() function

### DIFF
--- a/src/Cart/CartContent.php
+++ b/src/Cart/CartContent.php
@@ -17,4 +17,11 @@ class CartContent extends Collection
             return $cartItem->subtotal();
         });
     }
+
+    public function subtotalWithoutConditions()
+    {
+        return $this->sum(function (CartItem $cartItem) {
+            return $cartItem->subtotalWithoutConditions();
+        });
+    }
 }


### PR DESCRIPTION
Called in fixApportionment() in coupons condition