### PR TITLE
[Setup] Allow to set local and timezone at installation

### DIFF
--- a/src/System/Database/Seeds/DatabaseSeeder.php
+++ b/src/System/Database/Seeds/DatabaseSeeder.php
@@ -20,6 +20,10 @@ class DatabaseSeeder extends Seeder
 
     public static $seedDemo = true;
 
+    public static $siteLanguage = 'en';
+
+    public static $siteTimezone = 'Europe/London';
+
     /**
      * Run the database seeds.
      * @return void


### PR DESCRIPTION
As referenced in https://github.com/tastyigniter/TastyIgniter/issues/904

Reopen of https://github.com/tastyigniter/TastyIgniter/pull/908 and [/TastyIgniter/pull/991](https://github.com/tastyigniter/TastyIgniter/pull/991)

Choosing the language
![Screenshot 2022-06-16 at 16 27 38](https://user-images.githubusercontent.com/6750786/174092503-f794b943-4968-4bef-b57e-87aa7c788c94.png)



Split timezone selection:
Example choosing Africa
![image](https://user-images.githubusercontent.com/6750786/174091624-2b49e663-ed67-4bc9-9506-d9330f399d5b.png)

![image](https://user-images.githubusercontent.com/6750786/174091663-79ae8ea0-9b3c-4704-b203-9200fce952c8.png)
Example choosing Europe
![Screenshot 2022-06-16 at 16 24 32](https://user-images.githubusercontent.com/6750786/174091790-fb591cdf-a50f-4bd4-8226-5c3aa864a7b9.png)

